### PR TITLE
Add readme fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# egui-miniquad
+
+This library is a [`egui`](https://github.com/emilk/egui) integration using [`miniquad`](https://github.com/not-fl3/miniquad) as the rendering backend.
+
+# Build (linux)
+
+```sh
+cargo run --example test_window
+```
+
+# Build (others)
+
+Miniquad supports a lot of different build targets. See the different build instructions [here](https://github.com/not-fl3/miniquad#building-examples).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,11 @@ impl EguiMq {
         } = output;
 
         if let Some(url) = open_url {
-            if let Err(err) = webbrowser::open(&url) {
-                eprintln!("Failed to open url: {}", err);
+            #[cfg(target_os = "macos")]
+            {
+                if let Err(err) = webbrowser::open(&url) {
+                    eprintln!("Failed to open url: {}", err);
+                }
             }
         }
 


### PR DESCRIPTION
- fixes build from using the webbrowser crate, because this is only used in macos according to the cargo.toml
- adds readme with some very basic instructions


Also, I didnt include it in this PR, because i dont think Its up to me to decide, but could you add a license to this project please?