### PR TITLE
move drawing in separate method

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -49,11 +49,13 @@ impl mq::EventHandler for Stage {
         ctx.begin_default_pass(mq::PassAction::clear_color(0.0, 0.0, 0.0, 1.0));
         ctx.end_render_pass();
 
-        // Draw things behind egui here
-
         self.egui_mq.begin_frame(ctx);
         self.ui();
         self.egui_mq.end_frame(ctx);
+
+        // Draw things behind egui here
+
+        self.egui_mq.draw(ctx);
 
         // Draw things in front of egui here
 


### PR DESCRIPTION
This might be useful in egui bindings for macroquad, based on this crate.

Right now I am doing `egui-macroquad` crate, and found that current system with drawing right at end of the frame is doesn't fit into `macroquad` architecture. In `macroquad` it is more convenient to process input (keys, gui) in the beginning, and then to draw everything. For this reasons, there is [`draw_megaui`](https://docs.rs/megaui-macroquad/0.1.4/megaui_macroquad/fn.draw_megaui.html) function in other immediate-mode GUI that used in `macroquad`.