### PR TITLE
Fix blending

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -31,6 +31,7 @@ impl mq::EventHandler for Stage {
             }
 
             egui::Window::new("egui ❤ miniquad").show(egui_ctx, |ui| {
+                egui::widgets::global_dark_light_mode_buttons(ui);
                 ui.checkbox(&mut self.show_egui_demo_windows, "Show egui demo windows");
 
                 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -4,6 +4,7 @@ struct Stage {
     egui_mq: egui_mq::EguiMq,
     show_egui_demo_windows: bool,
     egui_demo_windows: egui_demo_lib::DemoWindows,
+    color_test: egui_demo_lib::ColorTest,
 }
 
 impl Stage {
@@ -12,6 +13,7 @@ impl Stage {
             egui_mq: egui_mq::EguiMq::new(ctx),
             show_egui_demo_windows: true,
             egui_demo_windows: Default::default(),
+            color_test: Default::default(),
         }
     }
 }
@@ -40,6 +42,14 @@ impl mq::EventHandler for Stage {
                         std::process::exit(0);
                     }
                 }
+            });
+
+            egui::Window::new("Color Test").show(egui_ctx, |ui| {
+                egui::ScrollArea::both()
+                    .auto_shrink([false; 2])
+                    .show(ui, |ui| {
+                        self.color_test.ui(ui);
+                    });
             });
         });
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -308,7 +308,7 @@ mod shader {
 
         v_tc = a_tc;
         v_rgba = a_srgba / 255.0;
-        v_rgba.a = v_rgba.a * v_rgba.a;
+        v_rgba.a = pow(v_rgba.a, 1.6);
     }
     "#;
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -29,6 +29,7 @@ impl Painter {
                     BlendFactor::One,
                     BlendFactor::OneMinusValue(BlendValue::SourceAlpha),
                 )),
+                cull_face: miniquad::CullFace::Nothing,
                 ..Default::default()
             },
         );
@@ -124,7 +125,7 @@ impl Painter {
                         "Mismatch between texture size and texel count"
                     );
 
-                    let gamma = 1.0;
+                    let gamma = 1.0 / 2.2;
                     let data: Vec<u8> = image
                         .srgba_pixels(gamma)
                         .flat_map(|a| a.to_array())
@@ -285,6 +286,19 @@ mod shader {
         return vec4(linear_from_srgb(srgba.rgb), srgba.a / 255.0);
     }
 
+    // 0-255 sRGB  from  0-1 linear
+    vec3 srgb_from_linear(vec3 rgb) {
+        bvec3 cutoff = lessThan(rgb, vec3(0.0031308));
+        vec3 lower = rgb * vec3(3294.6);
+        vec3 higher = vec3(269.025) * pow(rgb, vec3(1.0 / 2.4)) - vec3(14.025);
+        return mix(higher, lower, vec3(cutoff));
+    }
+
+    // 0-255 sRGBA  from  0-1 linear
+    vec4 srgba_from_linear(vec4 rgba) {
+        return vec4(srgb_from_linear(rgba.rgb), 255.0 * rgba.a);
+    }
+
     void main() {
         gl_Position = vec4(
             2.0 * a_pos.x / u_screen_size.x - 1.0,
@@ -293,7 +307,8 @@ mod shader {
             1.0);
 
         v_tc = a_tc;
-        v_rgba = linear_from_srgba(a_srgba);
+        v_rgba = a_srgba / 255.0;
+        v_rgba.a = v_rgba.a * v_rgba.a;
     }
     "#;
 
@@ -334,28 +349,29 @@ mod shader {
     void main() {
         // We must decode the colors, since WebGL1 doesn't come with sRGBA textures:
         vec4 texture_rgba = linear_from_srgba(texture2D(u_sampler, v_tc) * 255.0);
-        /// Multiply vertex color with texture color (in linear space).
-        gl_FragColor = v_rgba * texture_rgba;
 
         // WebGL1 doesn't support linear blending in the framebuffer,
         // so we do a hack here where we change the premultiplied alpha
         // to do the multiplication in gamma space instead:
 
         // Unmultiply alpha:
-        if (gl_FragColor.a > 0.0) {
-            gl_FragColor.rgb /= gl_FragColor.a;
+        if (texture_rgba.a > 0.0) {
+            texture_rgba.rgb /= texture_rgba.a;
         }
 
         // Empiric tweak to make e.g. shadows look more like they should:
-        gl_FragColor.a *= sqrt(gl_FragColor.a);
+        texture_rgba.a *= sqrt(texture_rgba.a);
 
         // To gamma:
-        gl_FragColor = srgba_from_linear(gl_FragColor) / 255.0;
+        texture_rgba = srgba_from_linear(texture_rgba) / 255.0;
 
         // Premultiply alpha, this time in gamma space:
-        if (gl_FragColor.a > 0.0) {
-            gl_FragColor.rgb *= gl_FragColor.a;
+        if (texture_rgba.a > 0.0) {
+            texture_rgba.rgb *= texture_rgba.a;
         }
+
+        /// Multiply vertex color with texture color (in linear space).
+        gl_FragColor = v_rgba * texture_rgba;
     }
     "#;
 


### PR DESCRIPTION
This PR fixes blending, making text look much clearer. I replaced the fragment shader code with the stuff from egui-glow, and I changed the `gamma` value in the texture update code to the one used in egui-glow.