### PR TITLE
Add file drag and drop support

### DIFF
--- a/docs/gl.js
+++ b/docs/gl.js
@@ -1222,6 +1222,33 @@ var importObject = {
                 }
             });
 
+            window.ondragover = function(e) {
+                e.preventDefault();
+            };
+
+            window.ondrop = async function(e) {
+                e.preventDefault();
+
+                wasm_exports.on_files_dropped_start();
+
+                for (let file of e.dataTransfer.files) {
+                    const nameLen = file.name.length;
+                    const nameVec = wasm_exports.allocate_vec_u8(nameLen);
+                    const nameHeap = new Uint8Array(wasm_memory.buffer, nameVec, nameLen);
+                    stringToUTF8(file.name, nameHeap, 0, nameLen);
+
+                    const fileBuf = await file.arrayBuffer();
+                    const fileLen = fileBuf.byteLength;
+                    const fileVec = wasm_exports.allocate_vec_u8(fileLen);
+                    const fileHeap = new Uint8Array(wasm_memory.buffer, fileVec, fileLen);
+                    fileHeap.set(new Uint8Array(fileBuf), 0);
+
+                    wasm_exports.on_file_dropped(nameVec, nameLen, fileVec, fileLen);
+                }
+
+                wasm_exports.on_files_dropped_finish();
+            };
+
             window.requestAnimationFrame(animation);
         },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod painter;
 
 // ----------------------------------------------------------------------------
 
-use egui::CursorIcon;
+use egui::{CursorIcon, DroppedFile};
 use miniquad as mq;
 
 #[cfg(target_os = "macos")] // https://github.com/not-fl3/miniquad/issues/172
@@ -311,6 +311,18 @@ impl EguiMq {
                 modifiers,
             })
         }
+    }
+
+    /// Call from your [`miniquad::EventHandler`].
+    pub fn files_dropped_event(&mut self) {
+        for i in 0..mq::dnd::dropped_file_count() {
+            self.egui_input.dropped_files.push(DroppedFile {
+                path: mq::dnd::dropped_file_path(i),
+                name: "".to_string(),
+                last_modified: None,
+                bytes: mq::dnd::dropped_file_bytes(i).map(|bytes| bytes.into()),
+            })
+        };
     }
 
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
This PR adds support for handling files that are dragged and dropped over the application.
Blocked by https://github.com/not-fl3/miniquad/pull/275.