### PR TITLE
Fix images not respecting nearest neighbour filter

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -88,6 +88,10 @@ impl Painter {
         delta: &egui::epaint::ImageDelta,
     ) {
         let [w, h] = delta.image.size();
+        let filter = match delta.options.magnification {
+            egui::TextureFilter::Nearest => miniquad::FilterMode::Nearest,
+            egui::TextureFilter::Linear => miniquad::FilterMode::Linear,
+        };
 
         if let Some([x, y]) = delta.pos {
             // Partial update
@@ -125,7 +129,7 @@ impl Painter {
             let params = miniquad::TextureParams {
                 format: miniquad::TextureFormat::RGBA8,
                 wrap: miniquad::TextureWrap::Clamp,
-                filter: miniquad::FilterMode::Linear,
+                filter,
                 width: w as _,
                 height: h as _,
             };


### PR DESCRIPTION
See issue #55

This is a hacky fix for the issue of images always being drawn with the linear filter, even when you set `TextureOptions::NEAREST`. This fix sets the filter based on what `TextureOptions` magnification is set to, so you can effectively specify either `TextureOptions::NEAREST` or `TextureOptions::LINEAR`, but you wouldn't be able to set different behaviour for minification.