### PR TITLE
Fix rustc E0027 when the accesskit feature is enabled on egui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ impl EguiMq {
             events: _,                    // no screen reader
             text_cursor_pos: _,           // no IME
             mutable_text_under_cursor: _, // no IME
+            ..
         } = platform_output;
 
         if let Some(url) = open_url {


### PR DESCRIPTION
Fixes issue https://github.com/not-fl3/egui-miniquad/issues/58.

To test it, enable the "accesskit" feature on the `egui` dependency and run `cargo check`. It should show no errors.