### PR TITLE
Update to egui 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Update to egui `0.23.0`
 
 # 0.14.0 - 2023-02-08
 * Update egui to `0.21.0`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 bytemuck = "1.9"
-egui = { version = "0.22.0", features = ["bytemuck"] }
+egui = { version = "0.23.0", features = ["bytemuck"] }
 miniquad = { version = "0.3.12" }
 quad-url = "0.1"
 
@@ -31,7 +31,7 @@ quad-rand = "0.2.1"
 copypasta = "0.8.1"
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.22.0", default-features = false }
+egui_demo_lib = { version = "0.23.0", default-features = false }
 glam = "0.22.0"
 
 [profile.release]


### PR DESCRIPTION
Everything seems fine, except for these weird lines that show up in the color test:

![image](https://github.com/not-fl3/egui-miniquad/assets/1148717/8a982818-5c4f-465c-a496-e55c649abb05)

They do not show up on egui.rs, so there is something wrong in the rendering here. Not sure what, and I don't feel like investigating it now.