### PR TITLE
Loosen miniquad version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 [dependencies]
 bytemuck = "1.9"
 egui = { version = "0.27", features = ["bytemuck"] }
-miniquad = { version = "=0.4.0" }
+miniquad = { version = "0.4.0" }
 quad-url = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Forcing a specific version of miniquad makes dependency resolution unnecesarily difficult. For example, by setting `=0.4.0` here, users of https://github.com/optozorax/egui-macroquad are limited to `macroquad@0.4.5` since that is the last published version that also has miniquad as `=0.4.0`.