### PR TITLE
New version for egui-macroquad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "miniquad"
-version = "0.4.0"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e9c578ad261f84512751bfdd9919c762ecd6103d06051fbdaede35136e1988"
+checksum = "0fc9c33a02870e728cf798dc0a69f29039f96ba13e46cde0f91d4b364eeb17a1"
 dependencies = [
  "libc",
  "ndk-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 bytemuck = "1.9"
-egui = { version = "0.28", features = ["bytemuck"] }
-miniquad = { version = "=0.4.0" }
+egui = { version = "0.28.1", features = ["bytemuck"] }
+miniquad = { version = "=0.4.5" }
 quad-url = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
I want to release new version of egui-macroquad, but there are conflicts between miniquad and macroquad versions, so I need latest miniquad in order to use latest macroquad.

Could you also please push new release to the crates after this PR?

@emilk