### PR TITLE
Update to egui 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 0.16.0 - 2025-
+* Update `egui` to `0.30.0`
+
 # 0.15.0 - 2024-07-08
 * Update `egui` to `0.28.0`
 * Update `miniquad` to `0.4.0`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-miniquad"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
   "Logachev Fedor <not.fl3@gmail.com>",
   "Emil Ernerfeldt <emil.ernerfeldt@gmail.com>",
@@ -18,7 +18,7 @@ include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 bytemuck = "1.9"
-egui = { version = "0.28", features = ["bytemuck"] }
+egui = { version = "0.30", features = ["bytemuck"] }
 miniquad = { version = "=0.4.0" }
 quad-url = "0.1"
 
@@ -31,7 +31,7 @@ quad-rand = "0.2.1"
 copypasta = "0.10.0"
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.28", default-features = false }
+egui_demo_lib = { version = "0.30", default-features = false }
 glam = "0.28.0"
 
 [profile.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ impl EguiMq {
     pub fn run(
         &mut self,
         mq_ctx: &mut dyn mq::RenderingBackend,
-        run_ui: impl FnOnce(&mut dyn mq::RenderingBackend, &egui::Context),
+        mut run_ui: impl FnMut(&mut dyn mq::RenderingBackend, &egui::Context),
     ) {
         input::on_frame_start(&mut self.egui_input, &self.egui_ctx);
 


### PR DESCRIPTION
I've been using these changes to run egui 0.30.0, so I figured I'd PR them. Sorry if I did things wrong, I am very inexperienced with `crates.io`. I presume the changelog section needs to match the date this is merged, so I left the month and date blank in the changelog to be fixed if this is ever ready for merge.

Also since this is a new minor release with major 0, the `FnOnce` -> `FnMut` change should be semvar fine. Should that be noted in the change log? I didn't since `FnMut` should be strictly less restrictive than `FnOnce`.

I also didn't include it here since I'm not sure if it's desirable, but for me I'd really like if `egui-miniquad` re-exported `egui` and `miniquad` so I don't have to manually make sure the version matches in my project's `cargo.toml`.