### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.16.0 - 2025-05-20
+* Update `egui` to `0.31.1`
+* Update `miniquad` to `0.4.8`
+
 # 0.15.0 - 2024-07-08
 * Update `egui` to `0.28.0`
 * Update `miniquad` to `0.4.0`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "egui-miniquad"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bytemuck",
  "copypasta",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.28.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
 
 [[package]]
 name = "hermit-abi"
@@ -599,9 +599,9 @@ checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 
 [[package]]
 name = "quad-rand"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quad-url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-miniquad"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
   "Logachev Fedor <not.fl3@gmail.com>",
   "Emil Ernerfeldt <emil.ernerfeldt@gmail.com>",
@@ -24,7 +24,7 @@ quad-url = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.7", features = ["custom"] }
-quad-rand = "0.2.1"
+quad-rand = "0.2.3"
 
 # https://github.com/not-fl3/miniquad/issues/172
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -32,7 +32,7 @@ copypasta = "0.10.0"
 
 [dev-dependencies]
 egui_demo_lib = { version = "0.31.1", default-features = false }
-glam = "0.28.0"
+glam = "0.30.3"
 
 [profile.release]
 opt-level = 2 # fast and small wasm


### PR DESCRIPTION
Hi all,

Follow up from yesterday's #79 . This should be the final update needed for a new release to be pushed to crates.io.

It bumps the version of `egui-miniquad` and updates the changelog. It also updates the versions of a couple minor dependencies including `quad-rand` and `glam`.

Hopefully @not-fl3 or @emilk can push a release to crates.io after this, I _think_ this should be the last step.

@optozorax This should unblock a new `equi-macroquad` release.